### PR TITLE
Allow for specifying default fallback server

### DIFF
--- a/src/main/java/nz/co/noirland/vanillapod/PodConfig.java
+++ b/src/main/java/nz/co/noirland/vanillapod/PodConfig.java
@@ -46,7 +46,7 @@ public class PodConfig {
                 }
             }
         }
-        return null;
+        return config.getString("default");
     }
 
     public Collection<String> getServers() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,10 +2,6 @@ servers:
   one-seven:
   - 4 # 1.7 - 1.7.4
   - 5 # 1.7.5 1.7.10
-  one-eight:
-  - 44 # 1.8-pre1
-  - 45 # 1.8-pre2
-  - 46 # 1.8-pre3
-  - 47 # 1.8
 ping-passthrough: true # Whether to passthrough pings
 ping-cache-delay: 5000 # Delay in milliseconds to cache pings
+default: one-eight


### PR DESCRIPTION
Allow for specifying default fallback server (e.g. lobby) and defining alternate-version servers

Created a change to allow a fallback default server if listed protocol is not found (e.g. Minecraft 1.10 hub) and multiple other versions as specific entries.
